### PR TITLE
https everywhere (except shapefiles)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ The project is in the public domain within the United States, and copyright and 
 
 All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
 
-[CC0]: http://creativecommons.org/publicdomain/zero/1.0/
+[CC0]: https://creativecommons.org/publicdomain/zero/1.0/

--- a/README.md
+++ b/README.md
@@ -14,23 +14,21 @@ To do:
 
 ## Using the shapes
 
-All files in this repository are automatically published to [theunitedstates.io](http://theunitedstates.io), at predictable URLs.
+All files in this repository are automatically published to [theunitedstates.io](https://theunitedstates.io), at predictable URLs.
 
 For example, GeoJSON for New York's 1st district can be found at:
 
-> [http://theunitedstates.io/districts/cds/2012/NY-1/shape.geojson](http://theunitedstates.io/districts/cds/2012/NY-1/shape.geojson)
+> [https://theunitedstates.io/districts/cds/2012/NY-1/shape.geojson](https://theunitedstates.io/districts/cds/2012/NY-1/shape.geojson)
 
 The `2012` here refers to the year that these districts came into effect, and is the most current districts. "At Large" districts, where only 1 person represents an entire state or territory, are coded with a district number of `0` (e.g. `WY-0` and `PR-0`).
 
 GeoJSON for the state of New York can be found at:
 
-> [http://theunitedstates.io/districts/states/NY/shape.geojson](http://theunitedstates.io/districts/states/NY/shape.geojson)
+> [https://theunitedstates.io/districts/states/NY/shape.geojson](https://theunitedstates.io/districts/states/NY/shape.geojson)
 
 Replace `.geojson` with `.kml` to get a KML version of a district.
 
 You can also download [the entire set as a ZIP file](https://github.com/unitedstates/districts/archive/gh-pages.zip), and use them however you like. If you plan on using these for heavy traffic, or you want control over the domain name they live on, you should use this method.
-
-We **cannot provide HTTPS permalinks** for these GeoJSON files, as [Github Pages does not support SSL](https://github.com/isaacs/github/issues/156). If you want to use these files on your website and worry about showing your users mixed content warnings, you'll need to host them elsewhere. If this seems weird to you, [write Github support](mailto:support@github.com) to request SSL support for Github Pages.
 
 ### Crawling/discovering shape URLs
 
@@ -51,13 +49,13 @@ Check out [mapshaper](https://github.com/mbloch/mapshaper) for all sorts of help
 These are just static shapes for current districts. If you want to do more, you might use:
 
 * Jeffrey B. Lewis' [collection of GeoJSON](https://github.com/JeffreyBLewis/congressional-district-boundaries) for every US congressional district, including historical shapes
-* The [US Census Bureau's API](http://www.census.gov/developers/)
-* GovTrack's [Boundary Service API](http://gis.govtrack.us/map/demo/cd-2012/)
+* The [US Census Bureau's API](https://www.census.gov/developers/)
+* GovTrack's [Boundary Service API](https://gis.govtrack.us/map/demo/cd-2012/)
 
 ## Public domain
 
 This project is [dedicated to the public domain](LICENSE). As spelled out in [CONTRIBUTING](CONTRIBUTING.md):
 
-> The project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](http://creativecommons.org/publicdomain/zero/1.0/).
+> The project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.


### PR DESCRIPTION
Github has started enabling HTTPS for custom domains [(see issue #156)](https://github.com/isaacs/github/issues/156). It looks like HTTPS was enabled through cloudflare back in 2015 on [this commit](https://github.com/unitedstates/images/issues/13) in response to [this issue](https://github.com/unitedstates/unitedstates.github.io/commit/9c52e0050de79046d0a37e141ba5588ea266ea49) which means the scary "NO HTTPS" warnings can get removed from the README.

🔐