### PR TITLE
Add script to produce FeatureCollection files per state and type of district

### DIFF
--- a/stateFeatureCollections.js
+++ b/stateFeatureCollections.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/**
+ *
+ */
+
+var fs = require('fs');
+var path = require('path');
+var pj = function() { return path.join.apply(null, arguments); }
+
+var statesDir = pj(__dirname, 'states');
+var states = fs.readdirSync(statesDir);
+var fiftys = states.filter(function (state) {
+  try {
+    var hasUpper = fs.statSync(pj(statesDir, state, 'sldu')).isDirectory();
+    var hasLower = fs.statSync(pj(statesDir, state, 'sldl')).isDirectory();
+    return hasUpper && hasLower;
+  } catch (e) { return false; }
+});
+
+console.log("Found", fiftys.length, "states to process.");
+
+
+function reduceState(state) {
+  var upperDir = pj(statesDir, state, 'sldu');
+  var upperDs = fs.readdirSync(upperDir);
+  var upperGeoJSON = upperDs.reduce(function (gJ, d) {
+    var district = JSON.parse(fs.readFileSync(pj(upperDir, d), 'utf-8'));
+    return gJ.features.push(district), gJ;
+  }, { type: 'FeatureCollection', features: [] });
+  fs.writeFileSync(pj(upperDir, 'sldu.json'), JSON.stringify(upperGeoJSON));
+  
+  var lowerDir = pj(statesDir, state, 'sldl');
+  var lowerDs = fs.readdirSync(lowerDir);
+  var lowerGeoJSON = lowerDs.reduce(function (gJ, d) {
+    var district = JSON.parse(fs.readFileSync(pj(lowerDir, d), 'utf-8'));
+    return gJ.features.push(district), gJ;
+  }, { type: 'FeatureCollection', features: [] });
+  fs.writeFileSync(pj(lowerDir, 'sldl.json'), JSON.stringify(lowerGeoJSON));
+}
+
+fiftys.forEach(reduceState);

--- a/stateFeatureCollections.js
+++ b/stateFeatureCollections.js
@@ -22,21 +22,28 @@ console.log("Found", fiftys.length, "states to process.");
 
 
 function reduceState(state) {
+  console.log("Upper: Reading");
   var upperDir = pj(statesDir, state, 'sldu');
   var upperDs = fs.readdirSync(upperDir);
   var upperGeoJSON = upperDs.reduce(function (gJ, d) {
     var district = JSON.parse(fs.readFileSync(pj(upperDir, d), 'utf-8'));
     return gJ.features.push(district), gJ;
   }, { type: 'FeatureCollection', features: [] });
+  console.log("Upper: Writing");
   fs.writeFileSync(pj(upperDir, 'sldu.json'), JSON.stringify(upperGeoJSON));
   
+  console.log("Lower: Reading");
   var lowerDir = pj(statesDir, state, 'sldl');
   var lowerDs = fs.readdirSync(lowerDir);
   var lowerGeoJSON = lowerDs.reduce(function (gJ, d) {
     var district = JSON.parse(fs.readFileSync(pj(lowerDir, d), 'utf-8'));
     return gJ.features.push(district), gJ;
   }, { type: 'FeatureCollection', features: [] });
+  console.log("Lower: Writing");
   fs.writeFileSync(pj(lowerDir, 'sldl.json'), JSON.stringify(lowerGeoJSON));
 }
 
-fiftys.forEach(reduceState);
+fiftys.forEach(function (state) {
+  console.log("Processing state", state);
+  reduceState(state);
+});


### PR DESCRIPTION
The script produces a FeatureCollection type of GeoJSON file which contains all the information in individual feature files representing individual districts. While the individual files system is a good way to organize information as an ultimate source-of-truth, the files this script produces are useful for gaining a big-picture perspective on the data. This script produces such files where applicable, is readable, and works rather quickly.

I have on my fork also a branch with the files it generates committed in case the maintainers of this repository find this to be an agreeable proposition. What do you guys think?